### PR TITLE
feat: Update utils and chat_logic modules

### DIFF
--- a/chat_logic/document_assistant.py
+++ b/chat_logic/document_assistant.py
@@ -1,0 +1,128 @@
+from typing import List, Optional
+from fastapi import UploadFile
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from utils import (
+    get_vectorstore, 
+    get_agent_executor,
+    generate_questions, 
+    remove_sources, 
+    process_documents,
+    get_session_history, 
+    process_url
+)
+
+
+async def handle_document(
+                    user_input: str, files: List[UploadFile], 
+                    session_id: str, usage: str):
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"Selected usage: {usage}")
+    
+    doc_list = []
+
+    # file, url을 문서로 변환
+    if files:
+        doc_list = await process_documents(doc_list=doc_list, files=files, session_id=session_id)
+
+    # 최종 문서 일부 내용
+    print(f"2nd Content: {doc_list[1].page_content[:100]}")
+    print(f"3rd Content: {doc_list[2].page_content[:100]}")
+    if doc_list:
+        vector_store = get_vectorstore(doc_list)
+        if vector_store is None:
+            raise ValueError("Error: vector_store is not initialized.")
+        
+        retriever = vector_store.as_retriever()
+    else:
+        retriever = None
+
+    agent_executor = get_agent_executor(usage, retriever)
+
+    # Create agent with chat history
+    agent_with_chat_history = RunnableWithMessageHistory(
+        agent_executor,
+        get_session_history,  # 직접 get_session_history 함수 전달
+        input_messages_key="input",
+        history_messages_key="chat_history"
+    )
+
+    # 대화 내역에 사용자 입력 추가
+    session_history = get_session_history(session_id)
+    session_history.add_message({"role": "user", "content": user_input})
+
+    # 에이전트를 통해 응답 생성
+    response = agent_with_chat_history.invoke(
+        {"input": user_input},
+        config={"configurable": {"session_id": session_id}}  # 세션 ID를 포함하여 호출
+    )
+    
+    # 특수문자 제거
+    answer = remove_sources(response["output"])
+    
+    # 응답을 대화 내역에 추가
+    session_history.add_message({"role": "assistant", "content": answer})
+    
+    # 관련질문 생성
+    references = generate_questions(answer)
+    
+    return {"response": answer, "references": references}
+
+
+async def handle_url(user_input: str, session_id: str, 
+                     url: Optional[str], usage: str):
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"URL: {url}")
+    print(f"Selected usage: {usage}")
+    
+    doc_list = []
+
+    # url을 문서로 변환
+    if url:
+        doc_list = await process_url(doc_list=doc_list, url=url, session_id=session_id)
+
+    # 최종 문서 일부 내용
+    print(f"2nd Content: {doc_list[1].page_content[:100]}")
+    print(f"3rd Content: {doc_list[2].page_content[:100]}")
+    if doc_list:
+        vector_store = get_vectorstore(doc_list)
+        if vector_store is None:
+            raise ValueError("Error: vector_store is not initialized.")
+        
+        retriever = vector_store.as_retriever()
+    else:
+        retriever = None
+
+    agent_executor = get_agent_executor(usage, retriever)
+
+    # Create agent with chat history
+    agent_with_chat_history = RunnableWithMessageHistory(
+        agent_executor,
+        get_session_history,  # 직접 get_session_history 함수 전달
+        input_messages_key="input",
+        history_messages_key="chat_history"
+    )
+
+    # 대화 내역에 사용자 입력 추가
+    session_history = get_session_history(session_id)
+    session_history.add_message({"role": "user", "content": user_input})
+
+    # 에이전트를 통해 응답 생성
+    response = agent_with_chat_history.invoke(
+        {"input": user_input},
+        config={"configurable": {"session_id": session_id}}  # 세션 ID를 포함하여 호출
+    )
+    
+    # 특수문자 제거
+    answer = remove_sources(response["output"])
+    
+    # 응답을 대화 내역에 추가
+    session_history.add_message({"role": "assistant", "content": answer})
+    
+    # 관련질문 생성
+    references = generate_questions(answer)
+    
+    return {"response": answer, "references": references}

--- a/chat_logic/manager.py
+++ b/chat_logic/manager.py
@@ -1,0 +1,93 @@
+from typing import List, Optional
+from fastapi import UploadFile
+from dotenv import load_dotenv
+from langchain_community.tools.tavily_search import TavilySearchResults
+from langchain_core.prompts import ChatPromptTemplate
+from typing import List, Optional
+from fastapi import UploadFile
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from utils import (get_vectorstore, get_agent_executor, get_web_loader,
+                   generate_questions, remove_sources, process_documents,
+                   get_session_history, process_url)
+
+async def handle_schedule(user_input: str,
+                          session_id: str,
+                          usage: str):
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"Selected usage: {usage}")
+
+    load_dotenv()
+
+    search = TavilySearchResults(
+        max_results=5,
+        include_answer=True,
+        include_raw_content=True,
+        description="If input query contains a request for information, please use this tool."
+    )
+    tools = [search]
+
+    # 프롬프트 생성
+    # 프롬프트는 에이전트에게 모델이 수행할 작업을 설명하는 텍스트를 제공합니다. (도구의 이름과 역할을 입력)
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful assistant. "
+                "The user will input their schedule. You should remember the schedule and use it in future conversations. "
+                "If you need information, you can use the agent tool."
+                "Please answer in Korean."
+            ),
+            ("placeholder", "{chat_history}"),
+            ("human", "{input}"),
+            ("placeholder", "{agent_scratchpad}"),
+        ]
+    )
+
+    # 에이전트 생성
+    from langchain_openai import ChatOpenAI
+    from langchain.agents import create_openai_tools_agent
+
+    # LLM 정의
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+    # Agent 생성
+    agent = create_openai_tools_agent(llm, tools, prompt)
+
+    from langchain.agents import AgentExecutor
+
+    # AgentExecutor 생성
+    agent_executor = AgentExecutor(
+        agent=agent,
+        tools=tools,
+        verbose=False
+    )
+    agent_with_chat_history = RunnableWithMessageHistory(
+        agent_executor,
+        get_session_history,  # 직접 get_session_history 함수 전달
+        input_messages_key="input",
+        history_messages_key="chat_history"
+    )
+
+    # 대화 내역에 사용자 입력 추가
+    session_history = get_session_history(session_id)
+    session_history.add_message({"role": "user", "content": user_input})
+
+    # 에이전트를 통해 응답 생성
+    response = agent_with_chat_history.invoke(
+        {"input": user_input},
+        config={"configurable": {"session_id": session_id}}  # 세션 ID를 포함하여 호출
+    )
+    
+    # 특수문자 제거
+    answer = remove_sources(response["output"])
+    
+    # 응답을 대화 내역에 추가
+    session_history.add_message({"role": "assistant", "content": answer})
+    # AgentExecutor 실행
+    answer = response["output"]
+    print("Agent 실행 결과:")
+    print(type(answer), answer)
+    
+    return {"response": answer}

--- a/chat_logic/recommend_place.py
+++ b/chat_logic/recommend_place.py
@@ -1,0 +1,93 @@
+from typing import List, Optional
+from fastapi import UploadFile
+from dotenv import load_dotenv
+from langchain_community.tools.tavily_search import TavilySearchResults
+from langchain_core.prompts import ChatPromptTemplate
+from typing import List, Optional
+from fastapi import UploadFile
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from utils import (remove_sources, get_session_history)
+
+async def handle_recommender(user_input: str, files: List[UploadFile], 
+                         session_id: str, url: Optional[str], 
+                         usage: str):
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"Selected usage: {usage}")
+
+    # 환경변수 불러오기기
+    load_dotenv()
+
+    # agent 도구 정의
+    search = TavilySearchResults(
+        max_results=5,
+        include_answer=True,
+        include_raw_content=True,
+        description="Use this tool to find place related to query"
+    )
+    tools = [search]
+
+    # 프롬프트 생성
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful assistant. "
+                "Make sure to use the `search` tool for searching keyword related place."
+                "Follow the format of response rules: place name, brief description, Url."
+                "If a URL is included, append it to each item."
+                "Please answer in Korean."
+            ),
+            ("placeholder", "{chat_history}"),
+            ("human", "{input}"),
+            ("placeholder", "{agent_scratchpad}"),
+        ]
+    )
+
+    # 에이전트 생성
+    from langchain_openai import ChatOpenAI
+    from langchain.agents import create_openai_tools_agent
+
+    # LLM 정의
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+    # Agent 생성
+    agent = create_openai_tools_agent(llm, tools, prompt)
+
+    from langchain.agents import AgentExecutor
+
+    # AgentExecutor 생성
+    agent_executor = AgentExecutor(
+        agent=agent,
+        tools=tools,
+        verbose=False
+    )
+    agent_with_chat_history = RunnableWithMessageHistory(
+            agent_executor,
+            get_session_history,  # 직접 get_session_history 함수 전달
+            input_messages_key="input",
+            history_messages_key="chat_history"
+            )
+
+    # 대화 내역에 사용자 입력 추가
+    session_history = get_session_history(session_id)
+    session_history.add_message({"role": "user", "content": user_input})
+
+    # 에이전트를 통해 응답 생성
+    response = agent_with_chat_history.invoke(
+        {"input": user_input},
+        config={"configurable": {"session_id": session_id}}  # 세션 ID를 포함하여 호출
+    )
+    
+    # 특수문자 제거
+    answer = remove_sources(response["output"])
+    
+    # 응답을 대화 내역에 추가
+    session_history.add_message({"role": "assistant", "content": answer})
+    # AgentExecutor 실행
+    answer = response["output"]
+    print("Agent 실행 결과:")
+    print(type(answer), answer)
+    
+    return {"response": answer}

--- a/chat_logic/report_maker.py
+++ b/chat_logic/report_maker.py
@@ -1,0 +1,208 @@
+from typing import List, Optional
+from fastapi import UploadFile
+from fastapi.responses import FileResponse
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from utils import (get_vectorstore, get_agent_executor, 
+                   generate_questions, remove_sources, process_documents,
+                   get_session_history)
+from dotenv import load_dotenv
+from langchain.tools.retriever import create_retriever_tool
+from langchain_core.prompts import PromptTemplate
+
+
+from langchain_community.tools.tavily_search import TavilySearchResults
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain.agents import create_tool_calling_agent, AgentExecutor
+from langchain_community.chat_message_histories import ChatMessageHistory
+from langchain_openai import ChatOpenAI
+from utils import get_session_history
+
+from langchain_community.utilities.dalle_image_generator import DallEAPIWrapper
+from langchain.tools import tool
+
+from langchain_community.agent_toolkits import FileManagementToolkit
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.vectorstores import faiss
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.document_loaders import PyMuPDFLoader
+
+# API 키 정보 로드
+load_dotenv()
+async def handle_report(user_input: str, files: List[UploadFile], 
+                      session_id: str, url: Optional[str], 
+                      usage: str):
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"Selected usage: {usage}")
+    
+    doc_list = []
+    # 파일 처리
+    if files:
+        doc_list = await process_documents(doc_list, files, session_id)
+
+    if doc_list:
+        vector_store = get_vectorstore(doc_list)
+        if vector_store is None:
+            raise ValueError("Error: vector_store is not initialized.")
+        
+        retriever = vector_store.as_retriever()
+    else:
+        retriever = None
+    search = TavilySearchResults(k=6)
+
+    # 문서의 내용을 표시하는 템플릿을 정의합니다.
+    document_prompt = PromptTemplate.from_template(
+        "<document><content>{page_content}</content><page>{page}</page><filename>{source}</filename></document>"
+    )
+
+    # retriever 를 도구로 정의합니다.
+    retriever_tool = create_retriever_tool(
+        retriever,
+        name="pdf_search",
+        description="use this tool to search for information in the PDF file",
+        document_prompt=document_prompt,
+    )
+
+
+    # DallE API Wrapper를 생성합니다.
+    dalle = DallEAPIWrapper(model="dall-e-3", size="1024x1024", quality="standard", n=1)
+
+
+    # DallE API Wrapper를 도구로 정의합니다.
+    @tool
+    def dalle_tool(query):
+        """use this tool to generate image from text"""
+        return dalle.run(query)
+
+
+    # 작업 디렉토리 경로 설정
+    working_directory = "tmp"
+
+    # 파일 관리 도구 생성(파일 쓰기, 읽기, 디렉토리 목록 조회)
+    file_tools = FileManagementToolkit(
+        root_dir=str(working_directory),
+        selected_tools=["write_file", "read_file", "list_directory"],
+    ).get_tools()
+
+    # 생성된 파일 관리 도구 출력
+    file_tools
+
+    tools = file_tools + [
+        retriever_tool,
+        search,
+        dalle_tool,
+    ]
+
+    # 최종 도구 목록 출력
+    tools
+
+
+    # session_id 를 저장할 딕셔너리 생성
+    store = {}
+
+    # 프롬프트 생성
+    # 프롬프트는 에이전트에게 모델이 수행할 작업을 설명하는 텍스트를 제공합니다. (도구의 이름과 역할을 입력)
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "You are a helpful assistant. "
+                "You are a professional researcher. "
+                "You can use the pdf_search tool to search for information in the PDF file. "
+                "You can find further information by using search tool. "
+                "You can use image generation tool to generate image from text. "
+                "Finally, you can use file management tool to save your research result into files.",
+            ),
+            ("placeholder", "{chat_history}"),
+            ("human", "{input}"),
+            ("placeholder", "{agent_scratchpad}"),
+        ]
+    )
+
+
+    # LLM 생성
+    llm = ChatOpenAI(model="gpt-4o-mini")
+
+    # Agent 생성
+    agent = create_tool_calling_agent(llm, tools, prompt)
+
+    # AgentExecutor 생성
+    agent_executor = AgentExecutor(
+        agent=agent,
+        tools=tools,
+        verbose=False,
+        handle_parsing_errors=True,
+    )
+
+
+    # 채팅 메시지 기록이 추가된 에이전트를 생성합니다.
+    agent_with_chat_history = RunnableWithMessageHistory(
+        agent_executor,
+        # 대화 session_id
+        get_session_history,
+        # 프롬프트의 질문이 입력되는 key: "input"
+        input_messages_key="input",
+        # 프롬프트의 메시지가 입력되는 key: "chat_history"
+        history_messages_key="chat_history",
+    )
+
+    # 에이전트 실행
+    result = agent_with_chat_history.stream(
+        {
+            "input": "삼성전자가 개발한 `생성형 AI` 와 관련된 유용한 정보들을 PDF 문서에서 찾아서 bullet point로 정리해 주세요. "
+            "한글로 작성해주세요."
+            "다음으로는 `report.md` 파일을 새롭게 생성하여 정리한 내용을 저장해주세요. \n\n"
+            "#작성방법: \n"
+            "1. markdown header 2 크기로 적절한 제목을 작성하세요. \n"
+            "2. 발췌한 PDF 문서의 페이지 번호, 파일명을 기입하세요(예시: page 10, filename.pdf). \n"
+            "3. 정리된 bullet point를 작성하세요. \n"
+            "4. 작성이 완료되면 파일을 `report.md` 에 저장하세요. \n"
+            "5. 마지막으로 저장한 `report.md` 파일을 읽어서 출력해 주세요. \n"
+        },
+        config={"configurable": {"session_id": session_id}},
+    )
+
+    # 웹 검색을 통해 보고서 파일 업데이트
+    result = agent_with_chat_history.stream(
+        {
+            "input": "이번에는 삼성전자가 개발한 `생성형 AI` 와 관련된 정보들을 웹 검색하고, 검색한 결과를 정리해 주세요. "
+            "한글로 작성해주세요."
+            "다음으로는 `report.md` 파일을 열어서 기존의 내용을 읽고, 웹 검색하여 찾은 정보를 이전에 작성한 형식에 맞춰 뒷 부분에 추가해 주세요. \n\n"
+            "#작성방법: \n"
+            "1. markdown header 2 크기로 적절한 제목을 작성하세요. \n"
+            "2. 정보의 출처(url)를 기입하세요(예시: 출처: 네이버 지식백과). \n"
+            "3. 정리된 웹검색 내용을 작성하세요. \n"
+            "4. 작성이 완료되면 파일을 `report.md` 에 저장하세요. \n"
+            "5. 마지막으로 저장한 `report.md` 파일을 읽어서 출력해 주세요. \n"
+        },
+        config={"configurable": {"session_id": session_id}},
+    )
+
+    # 보고서 작성을 요청합니다.
+    result = agent_with_chat_history.stream(
+        {
+            "input": "`report.md` 파일을 열어서 안의 내용을 출력하세요. "
+            "출력된 내용을 바탕으로, 전문적인 수준의 보고서를 작성하세요. "
+            "보고서는 총 3개의 섹션으로 구성되어야 합니다:\n"
+            "1. 개요: 보고서 abstract 를 300자 내외로 작성하세요.\n"
+            "2. 핵심내용: 보고서의 핵심 내용을 작성하세요. 정리된 표를 markdown 형식으로 작성하여 추가하세요. "
+            "3. 최종결론: 보고서의 최종 결론을 작성하세요. 출처(파일명, url 등)을 표시하세요."
+            "마지막으로 작성된 결과물을 `report-2.md` 파일에 저장하세요."
+        },
+        config={"configurable": {"session_id": session_id}},
+    )
+
+    # 이미지 생성을 요청합니다.
+    result = agent_with_chat_history.stream(
+        {
+            "input": "`report-2.md` 파일을 열어서 안의 내용을 출력하세요. "
+            "출력된 내용에 어울리는 이미지를 생성하세요. "
+            "생성한 이미지의 url 을 markdown 형식으로 보고서의 가장 상단에 추가하세요. "
+            "마지막으로 작성된 결과물을 `report-3.md` 파일에 저장하세요."
+        },
+        config={"configurable": {"session_id": session_id}},
+    )

--- a/chat_logic/summarizer.py
+++ b/chat_logic/summarizer.py
@@ -1,0 +1,132 @@
+import os
+from typing import List, Optional
+from fastapi import UploadFile
+from langchain import hub
+from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain_openai import ChatOpenAI
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_core.output_parsers import StrOutputParser
+from utils import (generate_questions, get_web_loader, validate_url,
+                   get_session_history, get_llm, get_prompt, get_document_loaders)
+
+from langchain_core.runnables import chain
+
+
+@chain
+def map_reduce_chain(docs, session_id):
+    map_llm = ChatOpenAI(
+        temperature=0,
+        model_name="gpt-4o-mini",
+    )
+
+    # map prompt 다운로드
+    map_prompt = hub.pull("teddynote/map-prompt")
+
+    # map chain 생성
+    map_chain = map_prompt | map_llm | StrOutputParser()
+
+    # 첫 번째 프롬프트, ChatOpenAI, 문자열 출력 파서를 연결하여 체인을 생성합니다.
+    doc_summaries = map_chain.batch(docs)
+
+    # reduce prompt 다운로드
+    reduce_prompt = hub.pull("teddynote/reduce-prompt")
+    reduce_llm = ChatOpenAI(
+        model_name="gpt-4o",
+        temperature=0,
+        streaming=True,
+    )
+
+    reduce_chain = reduce_prompt | reduce_llm | StrOutputParser()
+    reduce_chain_with_history = RunnableWithMessageHistory(
+        reduce_chain,
+        get_session_history,  # 직접 get_session_history 함수 전달
+        input_messages_key="input",
+        history_messages_key="chat_history"
+    )
+    return reduce_chain_with_history.invoke(
+        {"doc_summaries": doc_summaries, "language": "Korean"},
+        config={"configurable": {"session_id": session_id}})
+
+UPLOAD_DIRECTORY = "uploads"
+uploaded_files = {} 
+
+async def handle_summarize(user_input: str, files: List[UploadFile], 
+                      session_id: str, url: Optional[str], 
+                      usage: str):
+    # url 유효성 검사
+    print(f"handle_summarize's url: {url}")
+
+    # 입력받은 요소들을 로그에 남기기
+    print(f"User input: {user_input}")
+    print(f"Session ID: {session_id}")
+    print(f"URL: {url}")
+    print(f"Selected usage: {usage}")
+    
+    llm = get_llm()
+    doc_list = []
+    if files:
+        for file in files:
+            file_name = os.path.join(UPLOAD_DIRECTORY, file.filename)  # 업로드할 디렉토리 지정 
+            with open(file_name, "wb") as f:
+                f.write(await file.read())
+            print(f"Uploaded file: {file.filename}")
+
+            # 파일의 확장자에 따라 적절한 로더 사용
+            loader = get_document_loaders(file_name)
+            docs = loader.load()
+            doc_list.extend(docs)
+            if session_id not in uploaded_files:
+                uploaded_files[session_id] = []
+            uploaded_files[session_id].append(file_name)  # 세션 ID에 파일 경로 추가
+            os.remove(file_name)
+    if url:
+        loader = get_web_loader(url)
+        docs = loader.load()
+        doc_list.extend(docs)
+
+        if session_id not in uploaded_files:
+            uploaded_files[session_id] = []
+        uploaded_files[session_id].append(url)  # 세션 ID에 파일 경로 추가
+        print(f"Loaded documents from URL: {url}")
+    
+    if doc_list:
+        doc_len = "long" if len(doc_list) > 10 else "short"
+
+        if doc_len == "long":
+            response = map_reduce_chain.invoke(doc_list, session_id)
+        else:
+            stuff_chain = create_stuff_documents_chain(llm=llm, prompt=get_prompt()["summarize"][doc_len])
+            reduce_chain_with_history = RunnableWithMessageHistory(
+                stuff_chain,
+                get_session_history,  # 직접 get_session_history 함수 전달
+                input_messages_key="input",
+                history_messages_key="chat_history"
+            )
+            response = reduce_chain_with_history.invoke(
+                {"context": doc_list},
+                config={"configurable": {"session_id": session_id}})
+    else:
+        prompt = get_prompt()["general_prompt"]
+        llm = get_llm()
+        chain = prompt | llm | StrOutputParser()
+        chain_with_history = RunnableWithMessageHistory(
+            chain,
+            get_session_history,  # 직접 get_session_history 함수 전달
+            input_messages_key="input",
+            history_messages_key="chat_history"
+        )
+        response = chain_with_history.invoke(
+            {"user_input": user_input},
+            config={"configurable": {"session_id": session_id}}
+            )
+
+    # session id 생성
+    session_history = get_session_history(session_id)
+    # 대화 내역 추가
+    session_history.add_message({"role": "user", "content": user_input})
+    session_history.add_message({"role": "assistant", "content": response})
+        
+    # 관련질문 생성
+    references = generate_questions(response)
+    print(response)
+    return {"response": response, "references": references}

--- a/chat_logic/translator.py
+++ b/chat_logic/translator.py
@@ -1,0 +1,52 @@
+from typing import List, Optional
+from fastapi import UploadFile
+from dotenv import load_dotenv
+from langchain_core.runnables.history import RunnableWithMessageHistory
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from utils import (get_session_history, get_llm)
+load_dotenv()
+
+async def handle_translation(user_input: str, user_input2: str, 
+                     files: List[UploadFile], session_id: str, 
+                     url: Optional[str], usage: str):
+    # 입력받은 요소들을 출력
+    print(f"User input: {user_input}")
+    print(f"User input2: {user_input2}")
+    print(f"Session ID: {session_id}")
+    print(f"URL: {url}")
+    print(f"Selected usage: {usage}")
+
+    prompt = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                "당신은 번역 전문가입니다."
+                "입력 텍스트를 {target_language}로 번역해주세요"
+                "번역이 자연스럽도록 문장의 흐름과 맥락을 고려해 번역을 진행하세요."
+
+            ),
+            ("placeholder", "{chat_history}"),
+            ("human", "{input}"),
+        ]
+    )
+    
+    # chain 정의
+    llm = get_llm()
+    translation_chain = prompt | llm | StrOutputParser()
+    chain_with_history = RunnableWithMessageHistory(
+        translation_chain,
+        get_session_history,
+        input_messages_key="input",
+        history_messages_key="chat_history"
+    )
+
+    response = chain_with_history.invoke(
+        {
+            "input": user_input, 
+            "target_language": user_input2,
+        },
+        config={"configurable": {"session_id": session_id}}
+    )
+    print(f"Response: {response}")
+    return {"response": response}

--- a/templates/index.html
+++ b/templates/index.html
@@ -98,11 +98,13 @@
                 </span>
             <select id="usage-select" class="form-control" onchange="toggleSessionIdInput(); showDescription()"> <!-- 용도 선택 시 함수 호출 -->
                 <option value="" disabled selected hidden>선택하세요</option>
-                <option value="document_search">문서 검색</option>
-                <option value="summarize">페이지 요약</option>
+                <option value="document_search">문서 도우미</option>
+                <option value="summarize">요약</option>
+                <option value="recommend_place">장소 추천</option>
+                <option value="schedule_management">일정 관리</option>
                 <option value="translation">번역</option>
-                <option value="form_email">이메일 작성</option>
-                <option value="form_report">보고서 작성</option>
+                <option value="form_email">이메일 작성(Currently under development...)</option>
+                <option value="form_report">보고서 작성(Currently under development...)</option>
             </select>
         </div>
 
@@ -211,14 +213,14 @@
 
             if (usage === 'document_search') {
                 fileInput.style.display = 'block'; // 파일 입력 보임
-                urlInput.style.display = 'none'; // URL 입력창 숨김
+                urlInput.style.display = 'block'; // URL 입력창 숨김
             } else if (usage === 'summarize') {
                 fileInput.style.display = 'block'; // 파일 입력 숨김
-                urlInput.style.display = 'none'; // URL 입력창 보임
-            }else if (usage === 'agentic_rag') {
-                fileInput.style.display = 'block'; // 파일 입력 숨김
-                urlInput.style.display = 'none'; // URL 입력창 보임
-            } else if (usage === 'general') {
+                urlInput.style.display = 'block'; // URL 입력창 보임
+            }else if (usage === 'recommend_place') {
+                fileInput.style.display = 'none'; // 파일 입력 숨김
+                urlInput.style.display = 'none'; // URL 입력창 숨김
+            }else if (usage === 'translation') {
                 fileInput.style.display = 'none'; // 파일 입력 숨김
                 urlInput.style.display = 'none'; // URL 입력창 숨김
             }
@@ -266,10 +268,14 @@
             document.getElementById('loading-message').style.display = 'none';
             if (response.ok) {
                 const data = await response.json();
+                // 서버의 응답을 줄마다 분리하여 표시
+                const responseLines = data.response.split('\n'); // 줄바꿈을 기준으로 분리
+                const formattedResponse = responseLines.map(line => `<div style="margin-bottom: 10px;">${line}</div>`).join(''); // 각 줄 앞에 '- ' 추가
+
                 chatbox.innerHTML += `
                     <div class="message assistant">
                         <img src="/static/images/robot-icon.png" class="robot-icon" alt="Robot Icon" />
-                        ${data.response}
+                        ${formattedResponse}
                     </div>`;
                 
                 // 관련 질문 표시
@@ -280,7 +286,6 @@
                 
                 chatbox.innerHTML += `
                     <div class="message assistant">
-                        <div>관련 질문:</div>
                         ${referencesHtml}
                     </div>`;
                 


### PR DESCRIPTION
- utils.py
  - get_prompt 함수 수정
  - process_url 함수 추가: url의 컨텐츠를 문서화 하는 함수
  - reset_session 함수 위치를 handlers.py에서 utils.py로 변경
  - validate_url 함수 추가: url의 유효성 검증을 위한 함수

- chat_logic
  - 폴더 내 모듈 명 변경
    - agentic_rag_chat -> document_assistant
    - summary_chat -> summarizer
    - selres_chat -> recommend_place

  - 신규 모듈 추가
    - report_maker: 문서의 내용을 바탕으로 마크다운 형식의 보고서 작성
    - translater: 번역 기능을 수행
    - manager: llm을 통해 일정관리 기능을 수행

- index.html
  - 용도 선택창 옵션 추가: 장소추천, 일정관리, 번역